### PR TITLE
delete DATABASE_URL from ENV in spec_helper

### DIFF
--- a/spec/support/database.rb
+++ b/spec/support/database.rb
@@ -1,3 +1,5 @@
+ENV.delete('DATABASE_URL')
+
 require 'active_record'
 require 'active_support/concern'
 require 'logger'


### PR DESCRIPTION
extra safety net for not accidentally running specs against a remote database